### PR TITLE
Fix broken netlify build due to array.at()

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,6 @@ command = "npx pnpm i --store=node_modules/.pnpm-store && npx pnpm build"
 publish = "build"
 [build.environment]
 NPM_FLAGS = "--version"
+NODE_VERSION = "17.6.0"
 [functions]
 node_bundler = "esbuild"
-[build.environment]
-NODE_VERSION = "17.6.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,5 @@ publish = "build"
 NPM_FLAGS = "--version"
 [functions]
 node_bundler = "esbuild"
+[build.environment]
+NODE_VERSION = "17.6.0"

--- a/src/lib/components/footer.svelte
+++ b/src/lib/components/footer.svelte
@@ -12,7 +12,7 @@
     <p>
       {#each Object.entries(footerConfig.nav) as [href, name], i}
         <a {href} rel="noopener external" target="_blank">{name}</a>
-        {#if i < Object.keys(footerConfig.nav).length - 1}
+        {#if i + 1 < Object.keys(footerConfig.nav).length}
           <span class="mr-1">·</span>
         {/if}
       {/each}

--- a/src/lib/components/post_toc.svelte
+++ b/src/lib/components/post_toc.svelte
@@ -57,7 +57,7 @@
     toc={toc.reduce(
       (acc, heading) => {
         let parent = acc
-        while (parent.depth + 1 < heading.depth) parent = parent.children[parent.children.length - 1]
+        while (parent.depth + 1 < heading.depth) parent = parent.children.at(-1)
         parent.children = [...(parent.children ?? []), { ...heading, children: [] }]
         return acc
       },


### PR DESCRIPTION
If the build was only failing due to using `array.at()` which was [added in node v16.6.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility), then this should fix it and close #6.

Don't use Vercel myself. I presume you can set the node version similarly there.