### PR TITLE
Added dom library to tsconfig compilerOptions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "esnext",
-    "lib": ["esnext"],
+    "lib": [
+      "esnext",
+      "dom"
+    ],
     "target": "es2019",
     "noEmit": true,
     /**


### PR DESCRIPTION
This resolves missing reference warnings when variables like window.location.pathname are used in index.svelte