### PR TITLE
fix(package.json): 🐛 svelte-kit dev with MODE=development

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "node urara.js clean",
     "rename": "node urara.js rename",
     "dev:urara": "node urara.js watch",
-    "dev:kit": "export NODE_OPTIONS=--max_old_space_size=7680 && svelte-kit dev",
+    "dev:kit": "export NODE_OPTIONS=--max_old_space_size=7680 && MODE=development svelte-kit dev",
     "dev": "npm-run-all -p -r dev:urara \"dev:kit -- {@} \" --",
     "build:urara": "node urara.js build",
     "build:kit": "export NODE_OPTIONS=--max_old_space_size=7680 && svelte-kit build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "esnext",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
+    "lib": ["esnext", "dom"],
     "target": "es2019",
     "noEmit": true,
     /**


### PR DESCRIPTION
The dev script shall change to `MODE=development Svelte-kit dev` from `Svelte-kit dev` only, otherwise `import { dev } from '$app/env'` will always return false even if we are runing a dev server.

