### PR TITLE
refactor(header): :lipstick: fix width overflow

### DIFF
--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -54,7 +54,7 @@
 <header
   id="header"
   class:-translate-y-32={!pin && scrollY > 0}
-  class="fixed z-50 w-screen transition-all duration-500 ease-in-out border-b-2 border-transparent max-h-[4.125rem] {scrollY >
+  class="fixed z-50 w-full transition-all duration-500 ease-in-out border-b-2 border-transparent max-h-[4.125rem] {scrollY >
     32 && 'backdrop-blur !border-base-content/10 bg-base-100/30 md:bg-base-200/30'}">
   {#if !search}
     <div in:fly={{ x: -50, duration: 300, delay: 300 }} out:fly={{ x: -50, duration: 300 }} class="navbar">


### PR DESCRIPTION
Changed the tailwind class 'w-screen' to 'w-full' to ensure it doesn't overlap with the scrollbar.