### PR TITLE
The option for having remote images in blogs [Assets]

### DIFF
--- a/src/lib/components/head_opengraph.svelte
+++ b/src/lib/components/head_opengraph.svelte
@@ -15,7 +15,7 @@
       <meta property="og:description" content={post.summary} />
     {/if}
     {#if post.image}
-      <meta property="og:image" content={site.protocol + site.domain + post.image} />
+      <meta property="og:image" content={(post.image.startsWith('http') ? '' : site.protocol + site.domain) + post.image} />
       <meta name="twitter:card" content="summary_large_image" />
     {:else}
       <meta property="og:image" content={maskable['512'].src ?? any['512'].src ?? any['192'].src} />


### PR DESCRIPTION
This minor change, so the remote links can be used in the meta section: 

```svelte
<meta property="og:image" content={(post.image.startsWith('http') ? '' : site.protocol + site.domain) + post.image} />
```